### PR TITLE
fixed issue with numericality validator in combination with rails 5.2

### DIFF
--- a/lib/activerecord/tablefree/cast_type.rb
+++ b/lib/activerecord/tablefree/cast_type.rb
@@ -4,6 +4,11 @@ module ActiveRecord::Tablefree
       true
     end
 
+    # Needed for Rails 5.2 when using numericality validator
+    def value_constructed_by_mass_assignment?(_value)
+      false
+    end
+
     # Needed for Rails 5.0
     def serialize(args)
       args


### PR DESCRIPTION
I have tried to write a testcase but unfortunately they are already broken and i have no time fixing it.

The mentioned breaking validation looks like this:

```
validates :amount, presence: true,  numericality: { only_integer: true, greater_than: 0 }
```
Calling `.valid?` on the "model" raises a `method not found` error.